### PR TITLE
feat: add support for shared patches

### DIFF
--- a/app/src/main/java/app/revanced/manager/patcher/PatcherUtils.kt
+++ b/app/src/main/java/app/revanced/manager/patcher/PatcherUtils.kt
@@ -61,6 +61,6 @@ class PatcherUtils(val app: Application) {
 
     fun findPatchesByIds(ids: Iterable<String>): List<Class<out Patch<Context>>> {
         val (patches) = patches.value as? Resource.Success ?: return listOf()
-        return patches.filter { patch -> ids.any { it == patch.patchName } && patch.compatiblePackages!!.any { it.name == getSelectedPackageInfo()?.packageName } }
+        return patches.filter { patch -> ids.any { it == patch.patchName } && (patch.compatiblePackages?.any { it.name == getSelectedPackageInfo()?.packageName } == true || patch.compatiblePackages == null) }
     }
 }

--- a/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
+++ b/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
@@ -163,7 +163,7 @@ class PatcherWorker(
             )
 
 
-            Log.d(tag, "Adding ${patches.size} patch(es)")
+            Log.d(tag, "Adding ${patches.joinToString(", ") { it.name }} patch(es)")
             patcher.addPatches(patches)
 
             log("Merging integrations", INFO)

--- a/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
+++ b/app/src/main/java/app/revanced/manager/patcher/worker/PatcherWorker.kt
@@ -163,7 +163,7 @@ class PatcherWorker(
             )
 
 
-            Log.d(tag, "Adding ${patches.joinToString(", ") { it.name }} patch(es)")
+            Log.d(tag, "Adding ${patches.size} patch(es)")
             patcher.addPatches(patches)
 
             log("Merging integrations", INFO)

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/PatchesSelectorViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/PatchesSelectorViewModel.kt
@@ -45,14 +45,18 @@ class PatchesSelectorViewModel(
             loading = false; return
         }
         patches.forEach patch@{ patch ->
-            var unsupported = false
-            patch.compatiblePackages?.forEach { pkg ->
-                // if we detect unsupported once, don't overwrite it
-                if (pkg.name == selected.packageName) {
-                    if (!unsupported)
-                        unsupported =
-                            pkg.versions.isNotEmpty() && !pkg.versions.any { it == selected.versionName }
-                    filteredPatches.add(PatchClass(patch, unsupported))
+            if (patch.compatiblePackages == null) {
+                filteredPatches.add(PatchClass(patch, false))
+            } else {
+                var unsupported = false
+                patch.compatiblePackages?.forEach { pkg ->
+                    // if we detect unsupported once, don't overwrite it
+                    if (pkg.name == selected.packageName) {
+                        if (!unsupported)
+                            unsupported =
+                                pkg.versions.isNotEmpty() && !pkg.versions.any { it == selected.versionName }
+                        filteredPatches.add(PatchClass(patch, unsupported))
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adds support for shared patches, which doesn't have `compatiblePackages`.
+ If a patch in bundle doesn't have `compatiblePackages`, all user apps will be added to list.
+ If a patch has support for specific app(s), those will be added to list as well, even if they are system apps.